### PR TITLE
Refactor affiliate linking.

### DIFF
--- a/lib/ello_click/affiliate/link.ex
+++ b/lib/ello_click/affiliate/link.ex
@@ -1,0 +1,9 @@
+defmodule ElloClick.Affiliate.Link do
+  defstruct [original: nil, affiliated: nil, is_affiliated: false]
+
+  def affiliate(link, url) do
+    link
+    |> Map.put(:affiliated, url)
+    |> Map.put(:is_affiliated, true)
+  end
+end

--- a/lib/ello_click/affiliate/vig_link.ex
+++ b/lib/ello_click/affiliate/vig_link.ex
@@ -1,11 +1,13 @@
 defmodule ElloClick.Affiliate.VigLink do
   alias Plug.Conn
+  alias ElloClick.Affiliate.Link
 
   # Don't re-affiliate links something further up the chain got
-  def affiliate({:ok, affiliated}, _conn), do: {:ok, affiliated}
+  def affiliate(%Link{is_affiliated: true} = link, _conn), do: link
 
-  def affiliate(unaffiliated, conn) do
-    call_api(config.key, unaffiliated, referer(conn))
+  def affiliate(link, conn) do
+    {:ok, affiliated} = call_api(config.key, link.original, referer(conn))
+    Link.affiliate(link, affiliated)
   end
 
   # No API key


### PR DESCRIPTION
By using a struct to define the state of our original to affiliated
transformation we reveal more about our intentions.
