### PR TITLE
Adds Threadless Affiliation.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,10 @@ config :ello_click, viglink: %{
   key: System.get_env("VIGLINK_KEY"),
 }
 
+config :ello_click, threadless: %{
+  clickid: System.get_env("THREADLESS_CLICKID"),
+}
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,2 @@
 elixir_version=1.3.1
-config_vars_to_export=(VIGLINK_KEY)
+config_vars_to_export=(VIGLINK_KEY THREADLESS_CLICKID)

--- a/lib/ello_click/affiliate.ex
+++ b/lib/ello_click/affiliate.ex
@@ -1,5 +1,5 @@
 defmodule ElloClick.Affiliate do
-  alias ElloClick.Affiliate.{VigLink,Link}
+  alias ElloClick.Affiliate.{VigLink,Link,Threadless}
   @behaviour Plug
 
   def init(opts), do: opts
@@ -12,6 +12,7 @@ defmodule ElloClick.Affiliate do
   defp affiliate(conn) do
     %Link{original: conn.assigns.url}
     |> handle_ello
+    |> Threadless.affiliate(conn)
     |> VigLink.affiliate(conn)
     |> fallback
   end

--- a/lib/ello_click/affiliate/threadless.ex
+++ b/lib/ello_click/affiliate/threadless.ex
@@ -1,0 +1,34 @@
+defmodule ElloClick.Affiliate.Threadless do
+  alias ElloClick.Affiliate.Link
+
+  @ello_fake_threadless_affiliate "xrGWivQiB3WN3lVUxIzErxGGUkkz3ESwEVOtXE0"
+
+  # Don't re-affiliate links something further up the chain got
+  def affiliate(%Link{is_affiliated: true} = link, _conn), do: link
+
+  def affiliate(%Link{} = link, conn) do
+    if config.clickid && should_be_affiliated?(link.original) do
+      query = link.original
+              |> URI.parse
+              |> Map.get(:query)
+              |> URI.decode_query
+              |> Map.put("clickid", config.clickid)
+              |> URI.encode_query
+      affiliated = link.original
+                   |> URI.merge("?" <> query)
+                   |> URI.to_string
+      Link.affiliate(link, affiliated)
+    else
+      link
+    end
+  end
+
+  defp should_be_affiliated?(url) do
+    String.match?(url, ~r/https?:\/\/.*\.threadless\.com.*/) &&
+      !String.match?(url, ~r/clickid/)
+  end
+
+  defp config do
+    Application.get_env(:ello_click, :threadless, %{click_id: nil})
+  end
+end


### PR DESCRIPTION
At least a basic implementation of threadless affiliation based on the
premise that the `clickid` is standard across links for ello.
